### PR TITLE
Genpass fix

### DIFF
--- a/nimbis-ppc-gen-password
+++ b/nimbis-ppc-gen-password
@@ -29,7 +29,6 @@ pwd_context = LazyCryptContext(
 
     # set some useful global options
     default="sha256_crypt" if sys_bits < 64 else "sha512_crypt",
-    all__vary_rounds = 0.1,
 
     # Keep the number of rounds short, for a quicker-to-be-checked key
     sha512_crypt__max_rounds = 1000,


### PR DESCRIPTION
Sets a minimum for rounds (in addition to a max) to meet sha512_crypt round requirements.